### PR TITLE
mobile styling for boys and girls pgs

### DIFF
--- a/src/Routes/BoysSquadInTown/index.css
+++ b/src/Routes/BoysSquadInTown/index.css
@@ -58,4 +58,28 @@
 
 @media only screen and (min-width: 375px) and (max-width: 768px) {
     
+    .boysSquad-intown-page .title-row {
+        
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    }
+    .boysSquad-intown-page .title-row .column-one {
+  
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+    .boysSquad-intown-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+
 }

--- a/src/Routes/BoysSquadIndividual/index.css
+++ b/src/Routes/BoysSquadIndividual/index.css
@@ -76,3 +76,56 @@
     object-fit: contain;
     cursor: pointer;
 }
+
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+
+
+    .boysSquad-individual-page .model-collage h1 {
+visibility: hidden;
+    }
+    
+    .boysSquad-individual-page .hero .right-column {
+        visibility: hidden;
+    }
+    .boysSquad-individual-page .hero .left-column h1 {
+        font-size: 2em;
+    }
+    .boysSquad-individual-page .hero .left-column ul > li {
+        font-size: 1em;
+    }
+    .boysSquad-individual-page .hero .left-column {
+        display: flex;
+        flex-direction: column;
+        width: 60%;
+        height: 50vh;
+        font-family: 'Hemi Head';
+        text-transform: uppercase;
+        padding-left: 8rem;
+        margin-top: 4rem;
+    
+    }
+    
+
+    .boysSquad-individual-page .model-collage {
+        height: auto;
+        width: 90vw;
+        margin-top: -25%;
+    }
+
+    .boysSquad-individual-page .model-collage .collage img {
+        min-width: 30%;
+        width: 300px;
+        object-fit: contain;
+        cursor: pointer;
+    }
+
+    .boysSquad-individual-page .model-collage .collage video {
+        min-width: 30%;
+        width: 300px;
+        object-fit: contain;
+        cursor: pointer;
+    }
+
+}

--- a/src/Routes/BoysSquadOutOfTown/index.css
+++ b/src/Routes/BoysSquadOutOfTown/index.css
@@ -55,3 +55,34 @@
     width: 100%;
     text-transform: uppercase;
 }
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+    .boysSquad-outoftown-page .title-row {
+       
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    }
+    
+    .boysSquad-outoftown-page .title-row .column-one {
+       
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+
+    .boysSquad-outoftown-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+    
+
+}

--- a/src/Routes/BoysSquadUpcoming/index.css
+++ b/src/Routes/BoysSquadUpcoming/index.css
@@ -55,3 +55,35 @@
     width: 100%;
     text-transform: uppercase;
 }
+
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+    .boysSquad-upcoming-page .title-row {
+       
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    
+    }
+    
+    .boysSquad-upcoming-page .title-row .column-one {
+       
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+    .boysSquad-upcoming-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+    
+
+}

--- a/src/Routes/GirlsClubInTown/index.css
+++ b/src/Routes/GirlsClubInTown/index.css
@@ -55,3 +55,31 @@
     width: 100%;
     text-transform: uppercase;
 }
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+    .girlsclub-intown-page .title-row {
+        
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    }
+    .girlsclub-intown-page .title-row .column-one {
+  
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+    .girlsclub-intown-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+
+}

--- a/src/Routes/GirlsClubIndividual/index.css
+++ b/src/Routes/GirlsClubIndividual/index.css
@@ -76,3 +76,57 @@
     object-fit: contain;
     cursor: pointer;
 }
+
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+
+
+    .girlsclub-individual-page .model-collage h1 {
+visibility: hidden;
+    }
+    
+    .girlsclub-individual-page .hero .right-column {
+        visibility: hidden;
+    }
+    .girlsclub-individual-page .hero .left-column h1 {
+        font-size: 2em;
+    }
+    .girlsclub-individual-page .hero .left-column ul > li {
+        font-size: 1em;
+    }
+    .girlsclub-individual-page .hero .left-column {
+        display: flex;
+        flex-direction: column;
+        width: 60%;
+        height: 50vh;
+        font-family: 'Hemi Head';
+        text-transform: uppercase;
+        padding-left: 8rem;
+        margin-top: 4rem;
+    
+    }
+    
+
+    .girlsclub-individual-page .model-collage {
+        height: auto;
+        width: 90vw;
+        margin-top: -25%;
+    }
+
+    .girlsclub-individual-page .model-collage .collage img {
+        min-width: 30%;
+        width: 300px;
+        object-fit: contain;
+        cursor: pointer;
+    }
+
+    .girlsclub-individual-page .model-collage .collage video {
+        min-width: 30%;
+        width: 300px;
+        object-fit: contain;
+        cursor: pointer;
+    }
+
+
+}

--- a/src/Routes/GirlsClubOutOfTown/index.css
+++ b/src/Routes/GirlsClubOutOfTown/index.css
@@ -55,3 +55,31 @@
     width: 100%;
     text-transform: uppercase;
 }
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+    .girlsclub-outoftown-page .title-row {
+        
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    }
+    .girlsclub-outoftown-page .title-row .column-one {
+  
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+    .girlsclub-outoftown-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+
+}

--- a/src/Routes/GirlsClubUpcoming/index.css
+++ b/src/Routes/GirlsClubUpcoming/index.css
@@ -55,3 +55,31 @@
     width: 100%;
     text-transform: uppercase;
 }
+
+@media only screen and (min-width: 375px) and (max-width: 768px) {
+    
+    .girlsclub-upcoming-page .title-row {
+        
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: first baseline;
+        width: 80vw;
+        margin: 0 auto;
+        padding-bottom: 1rem;
+    }
+    .girlsclub-upcoming-page .title-row .column-one {
+  
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: space-between;
+        text-transform: uppercase;
+        max-width: 600px;
+        width: 60vw;
+    }
+    .girlsclub-upcoming-page .models-grid .model-cell {
+        max-width: 100%;
+        text-align: center;
+       
+    }
+
+}


### PR DESCRIPTION
Added media queries for Both Boys squad and girls club pages enabling the website to be responsive for mobile layout

Modifications;

Boys and Girls pgs (in town, upcoming, out of town):

title-row: re-arranged to column-wise 
model-cell: changed to 100% width upon switching mobile layout removing multiple pics in a single row

---------------------------------------------------------------------------------------
Boys and Girls Individual pgs:

upon switching to a mobile layout,

model name(h1)  & right column is hidden to reduce redundancy 
The main title and list elements font size reduced to the appropriate size
margin reduced by 25% at model-college class to decrease the gap between list elements and images
To avoid occupancy of full-screen, width of images and videos is reduced 


